### PR TITLE
Mention neo/legacy split in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,27 @@ Table (DHT), including:
   The test is run, in this repo, on a fake node, but it can be reused in other
   repos to test real node implementations. (``src.dhttest``)
 
+A Tale of Two Protocols
+-----------------------
+
+The code in this repo is currently in transition. There exist two parallel
+client/server architectures in the repo, a new architecture (dubbed "neo") --
+based on the core code in the ``swarm/neo`` package -- and a legacy architecture
+-- based on the core code located in the other packages of ``swarm``. The neo
+protocol is being introduced in stages, progressively adding features to the
+core client and server code over a series of alpha releases in a separate branch
+(named ``neo``).
+
+Note that the DHT client and node defined in this repo support *both* neo and
+legacy features.
+
+When the alpha releases are considered stable, the ``neo`` branch will be merged
+into the main release branch (currently ``v13.x.x``).
+
+When sufficient neo features have been implemented and the legacy protocol is no
+longer in active use, the legacy protocol will be deprecated and eventually
+removed.
+
 Dependencies
 ============
 


### PR DESCRIPTION
Fixes #6.