### PR TITLE
Switch to non-deprecated delegate type when calling sformat function

### DIFF
--- a/src/dhtproto/client/NotifierTypes.d
+++ b/src/dhtproto/client/NotifierTypes.d
@@ -46,11 +46,7 @@ public struct RequestRecordInfo
     public void toString ( void delegate ( cstring chunk ) sink )
     {
         Formatter.sformat(
-            ( cstring chunk )
-            {
-                sink(chunk);
-                return chunk.length;
-            },
+            sink,
             "Request #{} provided the record 0x{:x16}:{}",
             this.request_id, this.key, this.value);
     }
@@ -84,11 +80,7 @@ public struct RequestKeyInfo
     public void toString ( void delegate ( cstring chunk ) sink )
     {
         Formatter.sformat(
-            ( cstring chunk )
-            {
-                sink(chunk);
-                return chunk.length;
-            },
+            sink,
             "Request #{} provided the key 0x{:x16}",
             this.request_id, this.key);
     }


### PR DESCRIPTION
A couple of calls to `ocean.text.convert.Formatter.sformat` continue to use the deprecated `size_t delegate (cstring)` delegate format, perhaps in order to ensure compatibility with older ocean versions.

Since all supported minor releases of ocean (v3.2.x and v3.3.x) support the newer `void delegate (cstring)` (aka `FormatterSink`), and the `neo` branch is in any case pre-release code, it seems better to switch over to the new way of doing things.