### PR TITLE
Always unregister disconnect_detector in ListenRequest

### DIFF
--- a/src/dhtproto/node/request/Listen.d
+++ b/src/dhtproto/node/request/Listen.d
@@ -84,8 +84,15 @@ public abstract scope class Listen : SingleChannel
             // the cleanup also assumes the "write" event was active).
             this.writer.fiber.unregister();
             this.reader.fiber.epoll.register(disconnect_detector);
-            this.waitEvents(finish, flush);
-            this.reader.fiber.epoll.unregister(disconnect_detector);
+
+            try
+            {
+                this.waitEvents(finish, flush);
+            }
+            finally
+            {
+                this.reader.fiber.epoll.unregister(disconnect_detector);
+            }
 
             if (disconnect_detector.disconnected)
                 return;


### PR DESCRIPTION
For monitoring the connection state, while waiting for the
StorageEngine, Listen request is using the disconnect_detector. However,
if waiting for the storage engine throws, the disconnect_detector (the
scope class), stays registered in the epoll, causing the trigger and
possible crash, as the stack may not be here anymore.

This patch always unregisters disconnect_detector from epoll, nevermind
the return/exception of the waitEvents.