### PR TITLE
Change neo GetAll.getNext to work with a delegate, not a buffer copy

### DIFF
--- a/src/fakedht/neo/request/GetAll.d
+++ b/src/fakedht/neo/request/GetAll.d
@@ -167,16 +167,16 @@ private scope class GetAllImpl_v0 : GetAllProtocol_v0
         Gets the next record in the iteration, if one exists.
 
         Params:
-            key = receives the key of the next record, if available
-            value = receives the value of the next record, if available
+            dg = called with the key and value of the next record, if available
 
         Returns:
-            true if a record was returned via the out arguments or false if the
-            iteration is finished
+            true if a record was passed to `dg` or false if the iteration is
+            finished
 
     ***************************************************************************/
 
-    override protected bool getNext ( out hash_t key, ref void[] value )
+    override protected bool getNext (
+        void delegate ( hash_t key, Const!(void)[] value ) dg )
     {
         if ( this.iterate_keys.length == 0 )
             return false;
@@ -184,10 +184,12 @@ private scope class GetAllImpl_v0 : GetAllProtocol_v0
         auto str_key = this.iterate_keys[$-1];
         this.iterate_keys.length = this.iterate_keys.length - 1;
 
+        hash_t key;
         auto ok = toHashT(str_key, key);
         assert(ok);
-        value = this.channel.get(key).dup;
+        auto value = this.channel.get(key);
 
+        dg(key, value);
         return true;
     }
 }


### PR DESCRIPTION
This allows the storage engine to pass a slice of its contents to the
request handler's delegate, rather than requiring a copy into the handler's
buffer for each record. This is an optimisation that reduces CPU load
during iteration over large channels.

Part of https://github.com/sociomantic-tsunami/dhtnode/issues/19