### PR TITLE
Use ocean's new Logger

### DIFF
--- a/src/dhtproto/client/request/internal/Get.d
+++ b/src/dhtproto/client/request/internal/Get.d
@@ -19,7 +19,7 @@ module dhtproto.client.request.internal.Get;
 *******************************************************************************/
 
 import ocean.transition;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 /*******************************************************************************
 

--- a/src/dhtproto/client/request/internal/GetAll.d
+++ b/src/dhtproto/client/request/internal/GetAll.d
@@ -13,7 +13,7 @@
 module dhtproto.client.request.internal.GetAll;
 
 import ocean.transition;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 /*******************************************************************************
 

--- a/src/dhtproto/client/request/internal/GetChannels.d
+++ b/src/dhtproto/client/request/internal/GetChannels.d
@@ -13,7 +13,7 @@
 module dhtproto.client.request.internal.GetChannels;
 
 import ocean.transition;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 /*******************************************************************************
 

--- a/src/dhtproto/client/request/internal/GetHashRange.d
+++ b/src/dhtproto/client/request/internal/GetHashRange.d
@@ -17,7 +17,7 @@
 module dhtproto.client.request.internal.GetHashRange;
 
 import ocean.transition;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 import dhtproto.common.GetHashRange;
 import swarm.neo.client.NotifierTypes;
 

--- a/src/dhtproto/client/request/internal/Mirror.d
+++ b/src/dhtproto/client/request/internal/Mirror.d
@@ -13,7 +13,7 @@
 module dhtproto.client.request.internal.Mirror;
 
 import ocean.transition;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 /*******************************************************************************
 

--- a/src/dhtproto/client/request/internal/Put.d
+++ b/src/dhtproto/client/request/internal/Put.d
@@ -19,7 +19,7 @@ module dhtproto.client.request.internal.Put;
 *******************************************************************************/
 
 import ocean.transition;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 /*******************************************************************************
 

--- a/src/dhtproto/node/neo/request/GetAll.d
+++ b/src/dhtproto/node/neo/request/GetAll.d
@@ -12,7 +12,7 @@
 
 module dhtproto.node.neo.request.GetAll;
 
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 /// ditto
 public abstract scope class GetAllProtocol_v0

--- a/src/dhtproto/node/neo/request/Mirror.d
+++ b/src/dhtproto/node/neo/request/Mirror.d
@@ -12,7 +12,7 @@
 
 module dhtproto.node.neo.request.Mirror;
 
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 version ( UnitTest )
 {

--- a/src/dhttest/DhtTestCase.d
+++ b/src/dhttest/DhtTestCase.d
@@ -112,7 +112,7 @@ abstract class NeoDhtTestCase : TestCase
     import ocean.core.Enforce;
     import ocean.task.Scheduler;
     import ocean.task.Task;
-    import ocean.util.log.Log;
+    import ocean.util.log.Logger;
     import dhtproto.client.DhtClient;
     import Legacy = dhttest.DhtClient;
     import swarm.neo.authentication.HmacDef: Key;


### PR DESCRIPTION
Fixes some deprecation warnings in apps using dhtproto.

(Forgotten commit for neo-alpa-4. Will retag, as it's only a pre-release.)