### PR TITLE
Fix handling of error notifications in task-blocking all-nodes requests

### DIFF
--- a/src/dhtproto/client/mixins/NeoSupport.d
+++ b/src/dhtproto/client/mixins/NeoSupport.d
@@ -1175,10 +1175,9 @@ template NeoSupport ( )
                         if (this.state == State.Stopped)
                             break;
 
-                        // Otherwise flag an error and finish.
-                        this.state = State.Finished;
+                        // Otherwise flag an error and allow the request to
+                        // finish normally.
                         this.error = true;
-                        this.task.resume();
                         break;
 
                     case received_key:
@@ -1355,10 +1354,9 @@ template NeoSupport ( )
                         if (this.state == State.Stopped)
                             break;
 
-                        // Otherwise flag an error and finish.
-                        this.state = State.Finished;
+                        // Otherwise flag an error and allow the request to
+                        // finish normally.
                         this.error = true;
-                        this.task.resume();
                         break;
 
                     default: assert(false);


### PR DESCRIPTION
Previously, the following would happen:
1. An error occurs. The user's node_error notifier is called.
2. The notifier resumes the blocked fiber.
3. Eventually, the request finishes. The user's finished notifier is called.
4. The notifier resumes the blocked fiber. Oops, it's actually not
   suspended any more.

Fixes #67.