### PR TITLE
Remove Listen DisconnectDetector from epoll selected set when unregis…

### DIFF
--- a/src/dhtproto/node/request/Listen.d
+++ b/src/dhtproto/node/request/Listen.d
@@ -19,6 +19,8 @@ module dhtproto.node.request.Listen;
 *******************************************************************************/
 
 import ocean.transition;
+import ocean.core.Traits;
+import ocean.io.select.client.model.ISelectClient;
 
 import dhtproto.node.request.model.SingleChannel;
 
@@ -91,7 +93,17 @@ public abstract scope class Listen : SingleChannel
             }
             finally
             {
-                this.reader.fiber.epoll.unregister(disconnect_detector);
+                // deprecated: in next major, only the else branch should be
+                // left (starting from major that supports at least ocean v4.1.0).
+                static if (hasMethod!(typeof(this.reader.fiber.epoll),
+                                  "unregister", int delegate(ISelectClient, bool)))
+                {
+                    this.reader.fiber.epoll.unregister(disconnect_detector, true);
+                }
+                else
+                {
+                    this.reader.fiber.epoll.unregister(disconnect_detector);
+                }
             }
 
             if (disconnect_detector.disconnected)


### PR DESCRIPTION
…tering

A DisconnectDetector instance is newed on the stack, registered with
epoll, then unregistered when either an event occurs on the listened
channel or waitEvents throws.

It is possible, in the case of an exception being thrown, that the
DisconnectDetector has already fired in epoll, and is thus in the
selected set being iterated over. As an exception will cause the
Listen.handleChannelRequest method to exit, the DisconnectDetector will
go out of scope. Thus, when the selected set iteration comes to handle
it, a segfault will likely result.

If the ocean is at version v3.6.x or newer), we'll remove the
DisconnectDetector from epoll's selected set when unregistering, making
sure this instance will not be handled.

Fixes #114