### PR TITLE
Enable errors for deprecations and fix those

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -5,6 +5,7 @@ override DFLAGS  += -w
 ifeq ($(DVER),1)
 override DFLAGS += -v2 -v2=-static-arr-params -v2=-volatile
 else
+override DFLAGS  += -de
 DC:=dmd-transitional
 endif
 

--- a/src/dhtproto/client/DhtClient.d
+++ b/src/dhtproto/client/DhtClient.d
@@ -748,7 +748,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct Put
+    public struct Put
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -788,7 +788,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct Get
+    public struct Get
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -826,7 +826,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct Exists
+    public struct Exists
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -860,7 +860,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct Remove
+    public struct Remove
     {
         mixin RequestBase;
         mixin Channel;          // channel(cstring) method
@@ -901,7 +901,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct GetAll
+    public struct GetAll
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -947,7 +947,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct GetAllKeys
+    public struct GetAllKeys
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -991,7 +991,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct Listen
+    public struct Listen
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -1037,7 +1037,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct GetChannels
+    public struct GetChannels
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -1078,7 +1078,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct GetSize
+    public struct GetSize
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -1120,7 +1120,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct GetChannelSize
+    public struct GetChannelSize
     {
         mixin RequestBase;
         mixin Channel;          // channel(cstring) method
@@ -1155,7 +1155,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct RemoveChannel
+    public struct RemoveChannel
     {
         mixin RequestBase;
         mixin Channel;          // channel(cstring) method
@@ -1196,7 +1196,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct GetNumConnections
+    public struct GetNumConnections
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -1240,7 +1240,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct GetVersion
+    public struct GetVersion
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method
@@ -1282,7 +1282,7 @@ public class DhtClient : IClient
 
     ***************************************************************************/
 
-    private struct GetResponsibleRange
+    public struct GetResponsibleRange
     {
         mixin RequestBase;
         mixin IODelegate;       // io(T) method

--- a/src/dhtproto/client/legacy/internal/RequestSetup.d
+++ b/src/dhtproto/client/legacy/internal/RequestSetup.d
@@ -25,10 +25,6 @@ module dhtproto.client.legacy.internal.RequestSetup;
 
 public import swarm.client.RequestSetup;
 
-static import swarm.util.Hash;
-
-
-
 /*******************************************************************************
 
     Mixin for the methods use by dht client requests which have an I/O delegate.
@@ -184,6 +180,7 @@ public template Key ( )
 {
     import ocean.transition;
     import ocean.core.TypeConvert : downcast;
+    static import swarm.util.Hash;
 
     mixin TypeofThis;
     static assert (is(This == struct));

--- a/src/dhtproto/client/legacy/internal/connection/DhtRequestConnection.d
+++ b/src/dhtproto/client/legacy/internal/connection/DhtRequestConnection.d
@@ -46,6 +46,7 @@ import swarm.client.request.GetChannelSizeRequest;
 import swarm.client.request.GetSizeRequest;
 import swarm.client.request.RemoveChannelRequest;
 
+import dhtproto.client.legacy.internal.request.model.IDhtRequestResources;
 import dhtproto.client.legacy.internal.request.GetVersionRequest;
 import dhtproto.client.legacy.internal.request.GetResponsibleRangeRequest;
 import dhtproto.client.legacy.internal.request.GetRequest;
@@ -70,23 +71,23 @@ import dhtproto.client.legacy.DhtConst;
 *******************************************************************************/
 
 private alias GetChannelsRequestTemplate!(IRequest,
-    IRequest.IDhtRequestResources, DhtConst.Command.E.GetChannels)
+    IDhtRequestResources, DhtConst.Command.E.GetChannels)
     GetChannelsRequest;
 
 private alias GetNumConnectionsRequestTemplate!(IRequest,
-    IRequest.IDhtRequestResources, DhtConst.Command.E.GetNumConnections)
+    IDhtRequestResources, DhtConst.Command.E.GetNumConnections)
     GetNumConnectionsRequest;
 
 private alias GetChannelSizeRequestTemplate!(IChannelRequest,
-    IRequest.IDhtRequestResources, DhtConst.Command.E.GetChannelSize)
+    IDhtRequestResources, DhtConst.Command.E.GetChannelSize)
     GetChannelSizeRequest;
 
 private alias GetSizeRequestTemplate!(IRequest,
-    IRequest.IDhtRequestResources, DhtConst.Command.E.GetSize)
+    IDhtRequestResources, DhtConst.Command.E.GetSize)
     GetSizeRequest;
 
 private alias RemoveChannelRequestTemplate!(IChannelRequest,
-    IRequest.IDhtRequestResources, DhtConst.Command.E.RemoveChannel)
+    IDhtRequestResources, DhtConst.Command.E.RemoveChannel)
     RemoveChannelRequest;
 
 

--- a/src/fakedht/request/Listen.d
+++ b/src/fakedht/request/Listen.d
@@ -21,6 +21,7 @@ module fakedht.request.Listen;
 import ocean.transition;
 import ocean.util.log.Logger;
 
+import swarm.util.Hash;
 import Protocol = dhtproto.node.request.Listen;
 import fakedht.Storage; // DhtListener
 
@@ -142,7 +143,7 @@ public scope class Listen : Protocol.Listen, DhtListener
     override protected bool getNextRecord( cstring channel_name, mstring key,
         out Const!(void)[] value )
     {
-        assert (key.length == Hash.HashDigits);
+        assert (key.length == HashDigits);
 
         if (this.remaining_keys.length == 0)
             return false;

--- a/src/turtle/env/Dht.d
+++ b/src/turtle/env/Dht.d
@@ -27,6 +27,8 @@ import ocean.task.Scheduler;
 import ocean.task.util.Timer;
 import ocean.text.convert.Formatter;
 
+import swarm.Const : NodeItem;
+
 /*******************************************************************************
 
     Aliases to exceptions thrown on illegal operations with dht storage


### PR DESCRIPTION
Bunch of 2.071 deprecations were not noticed previously because dhtproto
was not compiled with -de flag.

Should be backwards compatible fix AFAICS but please recheck.