### PR TITLE
Tweak name of variable used in DhtHandshake timeout examples

### DIFF
--- a/relnotes/handshake.feature.md
+++ b/relnotes/handshake.feature.md
@@ -19,12 +19,12 @@ Stdout.formatln("At least one node is now connected!");
 // is only available for more recent ocean releases)
 auto timeout_microsec = 60_000_000;
 
-auto handshake_timeout =   // true if timeout is reached
+auto handshake_timed_out =   // true if timeout is reached
     theScheduler.awaitOrTimeout(
         handshake.allNodesConnected(),
         timeout_microsec);
 
-if (handshake_timeout)
+if (handshake_timed_out)
 {
     Stdout.formatln(
         "DHT handshake did not succeed within {} seconds!",

--- a/src/dhtproto/client/legacy/internal/helper/Handshake.d
+++ b/src/dhtproto/client/legacy/internal/helper/Handshake.d
@@ -221,12 +221,12 @@ unittest
             // ```
             // auto timeout_microsec = 60_000_000;
             //
-            // auto handshake_timeout =   /* true if timeout is reached */
+            // auto handshake_timed_out =   /* true if timeout is reached */
             //     theScheduler.awaitOrTimeout(
             //         this.handshake.allNodesConnected(),
             //         timeout_microsec);
             //
-            // /* react to `handshake_timeout` as you wish, but note
+            // /* react to `handshake_timed_out` as you wish, but note
             //    that the `DhtHandshake` instance will keep working
             //    in the background to complete the handshake */
             // ```


### PR DESCRIPTION
Bikesheddy, but this just lends itself to easier-to-understand code.

@gavin-norman-sociomantic somehow this feedback got offered in an application PR, but not to the actual usage examples in dhtproto! ;-)