### PR TITLE
Use IScheduler and awaitOrTimeout in DhtHandshake implementation and usage example

### DIFF
--- a/src/dhtproto/client/legacy/internal/helper/Handshake.d
+++ b/src/dhtproto/client/legacy/internal/helper/Handshake.d
@@ -17,7 +17,7 @@ public class DhtHandshake
     import dhtproto.client.DhtClient;
     import dhtproto.client.legacy.internal.helper.RetryHandshake;
 
-    import ocean.task.Scheduler;
+    import ocean.task.IScheduler;
     import ocean.task.Task;
     import ocean.task.util.Event;
     import ocean.util.log.Logger;


### PR DESCRIPTION
We couldn't do this in https://github.com/sociomantic-tsunami/dhtproto/pull/129, since dhtproto v13.x.x needs to support older ocean versions that do not have the `IScheduler` interface or the `Scheduler.awaitOrTimeout` method.