### PR TITLE
Make DhtClient.DhtConnNotification public

### DIFF
--- a/src/dhtproto/client/mixins/NeoSupport.d
+++ b/src/dhtproto/client/mixins/NeoSupport.d
@@ -66,7 +66,7 @@ template NeoSupport ( )
 
         ***********************************************************************/
 
-        private alias SmartUnion!(DhtConnNotificationUnion) DhtConnNotification;
+        public alias SmartUnion!(DhtConnNotificationUnion) DhtConnNotification;
 
         /***********************************************************************
 


### PR DESCRIPTION
User code needs access to this symbol, as it's passed as an argument of the user connection notifier delegate.