### PR TITLE
Use v3 cachalot image

### DIFF
--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/dlang:v2
+FROM sociomantictsunami/dlang:v3


### PR DESCRIPTION
This images comes with the d-apt fixes not to use master sourceforge
repo, but the automatically selected mirror.