### PR TITLE
Limit the maximum length of the input array

### DIFF
--- a/src/dhtproto/client/legacy/internal/request/GetRequest.d
+++ b/src/dhtproto/client/legacy/internal/request/GetRequest.d
@@ -74,7 +74,11 @@ public scope class GetRequest : IKeyRequest
 
     override protected void handle__ ( )
     {
-        this.reader.readArray(*this.resources.value_buffer);
+        if (!this.reader.readArrayLimit(*this.resources.value_buffer, MaximumRecordSize))
+        {
+            throw this.inputException.set(
+                    "Error while reading the record's value: too large");
+        }
 
         auto output = this.params.io_item.get_value();
 

--- a/src/dhtproto/client/legacy/internal/request/GetVersionRequest.d
+++ b/src/dhtproto/client/legacy/internal/request/GetVersionRequest.d
@@ -73,7 +73,11 @@ public scope class GetVersionRequest : IRequest
 
     override protected void handle__ ( )
     {
-        this.reader.readArray(*this.resources.value_buffer);
+        if (!this.reader.readArrayLimit(*this.resources.value_buffer, MaximumRecordSize))
+        {
+            throw this.inputException.set(
+                    "Error while reading the version value: too large");
+        }
 
         auto output = params.io_item.get_node_value();
         output(this.params.context, this.resources.conn_pool_info.address,

--- a/src/dhtproto/client/legacy/internal/request/ListenRequest.d
+++ b/src/dhtproto/client/legacy/internal/request/ListenRequest.d
@@ -145,8 +145,16 @@ public scope class ListenRequest : IChannelRequest, IStreamInfo
         do
         {
             // Read key & value
-            this.reader.readArray(*this.resources.key_buffer);
-            this.reader.readArray(*this.resources.value_buffer);
+            if (!this.reader.readArrayLimit(*this.resources.key_buffer, MaximumRecordSize))
+            {
+                throw this.inputException.set(
+                        "Error while reading the key: too large");
+            }
+            if (!this.reader.readArrayLimit(*this.resources.value_buffer, MaximumRecordSize))
+            {
+                throw this.inputException.set(
+                        "Error while reading the value: too large");
+            }
 
             // Forward value (unless end-of-flow marker)
             if ( this.resources.key_buffer.length )

--- a/src/dhtproto/client/legacy/internal/request/model/IBulkGetRequest.d
+++ b/src/dhtproto/client/legacy/internal/request/model/IBulkGetRequest.d
@@ -174,7 +174,11 @@ abstract private class IBulkGetRequest : IChannelRequest, IStreamInfo
 
     private bool readBatch ( )
     {
-        this.reader.readArray(*this.resources.batch_buffer);
+        if (!this.reader.readArrayLimit(*this.resources.batch_buffer, MaximumRecordSize))
+        {
+            throw this.inputException.set(
+                    "Error while reading the batch: too large");
+        }
 
         if ( this.resources.batch_buffer.length )
         {

--- a/src/dhtproto/client/legacy/internal/request/model/IRequest.d
+++ b/src/dhtproto/client/legacy/internal/request/model/IRequest.d
@@ -22,6 +22,8 @@ module dhtproto.client.legacy.internal.request.model.IRequest;
 
 import Core = swarm.client.request.model.IRequest;
 
+import ocean.core.Exception;
+
 import dhtproto.client.legacy.DhtConst;
 
 import dhtproto.client.legacy.internal.request.params.RequestParams;
@@ -50,6 +52,44 @@ public scope class IRequest : Core.IRequest
     protected alias .RequestParams RequestParams;
 
     protected alias .IDhtRequestResources IDhtRequestResources;
+
+
+    /***************************************************************************
+
+        Absolute maximum array size. Used for sanitizing the data input.
+        All records larger than this will be discarded.
+
+    **************************************************************************/
+
+    protected const MaximumRecordSize = 10 * 1024 * 1024;
+
+
+    /***************************************************************************
+
+        Exception instance to throw in case of the input validation error.
+
+    ***************************************************************************/
+
+    public static class InputTooLongException : Exception
+    {
+        mixin ReusableExceptionImplementation!();
+    }
+
+
+    /// ditto
+    protected static InputTooLongException inputException;
+
+
+    /***************************************************************************
+
+        Static constructor.
+
+    ***************************************************************************/
+
+    static this ()
+    {
+        IRequest.inputException = new InputTooLongException;
+    }
 
 
     /***************************************************************************

--- a/src/dhtproto/node/request/GetAllFilter.d
+++ b/src/dhtproto/node/request/GetAllFilter.d
@@ -60,7 +60,11 @@ public abstract scope class GetAllFilter : CompressedBatch!(mstring, mstring)
     final override protected void readChannelRequestData ( )
     {
         auto filter = this.resources.getFilterBuffer();
-        this.reader.readArray(*filter);
+        if (!this.reader.readArrayLimit(*filter, MaximumRecordSize))
+        {
+            throw this.inputException.set(
+                    "Error while reading the request filter: too large");
+        }
         this.prepareFilter(*filter);
     }
 

--- a/src/dhtproto/node/request/PutBatch.d
+++ b/src/dhtproto/node/request/PutBatch.d
@@ -69,7 +69,11 @@ public abstract scope class PutBatch : SingleChannel
 
     override protected void readChannelRequestData ( )
     {
-        this.reader.readArray(*this.record_buffer);
+        if (!this.reader.readArrayLimit(*this.record_buffer, MaximumRecordSize))
+        {
+            throw this.inputException.set(
+                    "Error while reading the batch array: too large");
+        }
     }
 
     /***************************************************************************

--- a/src/dhtproto/node/request/Redistribute.d
+++ b/src/dhtproto/node/request/Redistribute.d
@@ -131,7 +131,11 @@ public abstract scope class Redistribute : DhtCommand
                 (*this.redistribute_node_buffer).length + 1;
             auto next = &((*this.redistribute_node_buffer)[$-1]);
 
-            this.reader.readArray(next.node.Address);
+            if (!this.reader.readArrayLimit(next.node.Address, MaximumRecordSize))
+            {
+                throw this.inputException.set(
+                        "Error while reading the address of the next node: too large");
+            }
             if (next.node.Address.length == 0)
                 break;
             this.reader.read(next.node.Port);

--- a/src/dhtproto/node/request/model/DhtCommand.d
+++ b/src/dhtproto/node/request/model/DhtCommand.d
@@ -32,8 +32,44 @@ public abstract scope class DhtCommand : Command
 {
     import dhtproto.node.request.params.RedistributeNode;
 
+    import ocean.core.Exception;
     import swarm.util.RecordBatcher;
     import dhtproto.client.legacy.DhtConst;
+
+    /***************************************************************************
+
+        Absolute maximum record size. Used for sanitizing the data input.
+        All records larger than this will be discarded.
+
+    **************************************************************************/
+
+    protected const MaximumRecordSize = 10 * 1024 * 1024;
+
+    /***************************************************************************
+
+        Exception instance to throw in case of the input validation error.
+
+    ***************************************************************************/
+
+    public static class InputTooLongException : Exception
+    {
+        mixin ReusableExceptionImplementation!();
+    }
+
+    /// ditto
+    protected static InputTooLongException inputException;
+
+    /***************************************************************************
+
+        Static constructor.
+
+    ***************************************************************************/
+
+    static this ()
+    {
+        DhtCommand.inputException = new InputTooLongException;
+    }
+
 
     /***************************************************************************
     

--- a/src/dhtproto/node/request/model/SingleChannel.d
+++ b/src/dhtproto/node/request/model/SingleChannel.d
@@ -74,7 +74,11 @@ public abstract scope class SingleChannel : DhtCommand
 
     final override protected void readRequestData ( )
     {
-        this.reader.readArray(*this.channel_buffer);
+        if (!this.reader.readArrayLimit(*this.channel_buffer, MaximumRecordSize))
+        {
+            throw this.inputException.set(
+                    "Error while reading the channel buffer array: too large");
+        }
         this.readChannelRequestData();
     }
 

--- a/src/dhtproto/node/request/model/SingleKey.d
+++ b/src/dhtproto/node/request/model/SingleKey.d
@@ -75,7 +75,11 @@ public abstract scope class SingleKey : SingleChannel
 
     final override protected void readChannelRequestData ( )
     {
-        this.reader.readArray(*this.key_buffer);
+        if (!this.reader.readArrayLimit(*this.key_buffer, MaximumRecordSize))
+        {
+            throw this.inputException.set(
+                    "Error while reading the request key: too large");
+        }
         this.readKeyRequestData();
     }
 


### PR DESCRIPTION
Previously, no check for the array length was performed. This allowed
for badly behaving remote parties to perform DOS attack asking for
unreasonably large arrays to be allocated.

This limits the maximum array size to 10MB.