### PR TITLE
Add delegate to unregister RequestSuspender

### DIFF
--- a/relnotes/unregister_requestsuspender.feature.md
+++ b/relnotes/unregister_requestsuspender.feature.md
@@ -1,0 +1,7 @@
+### Add delegate to unregister RequestSuspender
+
+* `dhtproto.client.legacy.internal.request.model.IBulkGetRequest`
+* `dhtproto.client.legacy.internal.request.params.RequestParams`
+
+This new delegate should be used to remove an ISuspendable
+instance from a list of ISuspendables when a request finishes.

--- a/src/dhtproto/client/legacy/internal/request/model/IBulkGetRequest.d
+++ b/src/dhtproto/client/legacy/internal/request/model/IBulkGetRequest.d
@@ -40,6 +40,10 @@ import swarm.client.request.helper.RequestSuspender;
 
 import dhtproto.client.legacy.internal.request.model.IChannelRequest;
 
+import ocean.core.Verify;
+
+import ocean.core.VersionCheck;
+
 import ocean.io.select.client.FiberSelectEvent;
 
 import ocean.io.compress.lzo.LzoChunkCompressor;
@@ -137,6 +141,20 @@ abstract private class IBulkGetRequest : IChannelRequest, IStreamInfo
         {
             this.params.suspend_register(this.params.context,
                 this.resources.request_suspender);
+        }
+
+        // deprecated: remove in dhtproto v15
+        static if (hasFeaturesFrom!("swarm", 5, 3))
+        {
+            scope (exit)
+            {
+                if ( this.params.suspend_unregister !is null )
+                {
+                    verify(this.params.suspend_register !is null);
+                    this.params.suspend_unregister(this.params.context,
+                        this.resources.request_suspender);
+                }
+            }
         }
 
         // Pass stream info interface to user.

--- a/src/dhtproto/client/legacy/internal/request/params/RequestParams.d
+++ b/src/dhtproto/client/legacy/internal/request/params/RequestParams.d
@@ -126,6 +126,16 @@ public class RequestParams : IChannelRequestParams
 
     /***************************************************************************
 
+        Delegate which receives an ISuspendable interface when a suspendable
+        request finishes.
+
+    ***************************************************************************/
+
+    public RegisterSuspendableDg suspend_unregister;
+
+
+    /***************************************************************************
+
         Delegate which receives an IStreamInfo interface when a stream request
         has just started.
 


### PR DESCRIPTION
This new delegate should be used to remove an ISuspendable
instance from a list of ISuspendables when a request finishes.

See also (https://github.com/sociomantic-tsunami/swarm/pull/365)