### PR TITLE
Fix "race condition" in mirror helper

### DIFF
--- a/src/dhtproto/client/legacy/internal/helper/Mirror.d
+++ b/src/dhtproto/client/legacy/internal/helper/Mirror.d
@@ -107,14 +107,14 @@ abstract public class Mirror ( Dht : DhtClient ) : MirrorBase!(Dht)
             if ( start_in_ms == 0 )
             {
                 this.log.info("Starting.");
-                this.outer.dht.assign(rq);
                 this.state = State.Assigned;
+                this.outer.dht.assign(rq);
             }
             else
             {
                 this.log.info("Starting in {}ms.", start_in_ms);
-                this.outer.dht.schedule(rq, start_in_ms);
                 this.state = State.Scheduled;
+                this.outer.dht.schedule(rq, start_in_ms);
             }
         }
 


### PR DESCRIPTION
Assigning a request and changing the state are
assumed to be one atomic operation. However
assign calls other functions that might lead
into situations where the state is checked
although not yet changed.
Interchanging these commands solves this
problem in the given non threaded environments.