### PR TITLE
Stop using deprecated RecordBatch.DefaultMaxBatchSize

### DIFF
--- a/src/dhtproto/client/legacy/DhtConst.d
+++ b/src/dhtproto/client/legacy/DhtConst.d
@@ -66,7 +66,7 @@ static:
 
     ***************************************************************************/
 
-    public const RecordSizeLimit = RecordBatch.DefaultMaxBatchSize;
+    public const RecordSizeLimit = RecordBatcher.DefaultMaxBatchSize;
 
 
     /***************************************************************************

--- a/src/dhtproto/client/legacy/internal/connection/DhtRequestConnection.d
+++ b/src/dhtproto/client/legacy/internal/connection/DhtRequestConnection.d
@@ -229,7 +229,7 @@ public class DhtRequestConnection :
 
         override protected mstring new_batch_buffer ( )
         {
-            return new char[RecordBatch.DefaultMaxBatchSize];
+            return new char[DhtConst.RecordSizeLimit];
         }
 
 


### PR DESCRIPTION
RecordBatch.DefaultMaxBatchSize is marked as deprecated, yet is still used by dhtproto itself. Change the code to use the identically-defined RecordBatcher.DefaultMaxBatchSize instead.

This removes the annoying deprecation warning.