### PR TITLE
Fix missing 'import ocean.transition'

### DIFF
--- a/src/dhtproto/client/legacy/internal/registry/DhtNodeRegistry.d
+++ b/src/dhtproto/client/legacy/internal/registry/DhtNodeRegistry.d
@@ -43,6 +43,8 @@ import dhtproto.client.legacy.DhtConst;
 
 import dhtproto.client.legacy.internal.DhtClientExceptions;
 
+import ocean.transition;
+
 import ocean.io.select.EpollSelectDispatcher;
 
 import ocean.core.Enforce;


### PR DESCRIPTION
This module uses `mstring` and friends, but doesn't import them properly.
(The problem shows up after D2 conversion, when you try to compile with dmd 2.087).