### PR TITLE
Fix non-public imports to allow compilation with DMD 2.087

### DIFF
--- a/src/dhtproto/client/mixins/NeoSupport.d
+++ b/src/dhtproto/client/mixins/NeoSupport.d
@@ -103,16 +103,16 @@ template NeoSupport ( )
 
         private struct Internals
         {
-            import dhtproto.client.request.internal.GetHashRange;
-            import dhtproto.client.request.internal.Put;
-            import dhtproto.client.request.internal.Get;
-            import dhtproto.client.request.internal.Remove;
-            import dhtproto.client.request.internal.Mirror;
-            import dhtproto.client.request.internal.GetAll;
-            import dhtproto.client.request.internal.GetChannels;
-            import dhtproto.client.request.internal.Exists;
-            import dhtproto.client.request.internal.RemoveChannel;
-            import dhtproto.client.request.internal.Update;
+            public import dhtproto.client.request.internal.GetHashRange;
+            public import dhtproto.client.request.internal.Put;
+            public import dhtproto.client.request.internal.Get;
+            public import dhtproto.client.request.internal.Remove;
+            public import dhtproto.client.request.internal.Mirror;
+            public import dhtproto.client.request.internal.GetAll;
+            public import dhtproto.client.request.internal.GetChannels;
+            public import dhtproto.client.request.internal.Exists;
+            public import dhtproto.client.request.internal.RemoveChannel;
+            public import dhtproto.client.request.internal.Update;
         }
 
         /***********************************************************************

--- a/src/dhtproto/client/request/internal/Exists.d
+++ b/src/dhtproto/client/request/internal/Exists.d
@@ -59,7 +59,7 @@ static this ( )
 public struct Exists
 {
     import dhtproto.common.Exists;
-    import dhtproto.client.request.Exists;
+    public import dhtproto.client.request.Exists;
     import dhtproto.common.RequestCodes;
     import swarm.neo.client.mixins.RequestCore;
     import swarm.neo.client.RequestHandlers;

--- a/src/dhtproto/client/request/internal/Get.d
+++ b/src/dhtproto/client/request/internal/Get.d
@@ -59,7 +59,7 @@ static this ( )
 public struct Get
 {
     import dhtproto.common.Get;
-    import dhtproto.client.request.Get;
+    public import dhtproto.client.request.Get;
     import dhtproto.common.RequestCodes;
     import swarm.neo.client.mixins.RequestCore;
     import swarm.neo.client.RequestHandlers;

--- a/src/dhtproto/client/request/internal/GetAll.d
+++ b/src/dhtproto/client/request/internal/GetAll.d
@@ -41,7 +41,7 @@ import ocean.core.Verify;
 public struct GetAll
 {
     import dhtproto.common.GetAll;
-    import dhtproto.client.request.GetAll;
+    public import dhtproto.client.request.GetAll;
     import dhtproto.common.RequestCodes;
     import dhtproto.client.NotifierTypes;
     import swarm.util.RecordBatcher;

--- a/src/dhtproto/client/request/internal/GetChannels.d
+++ b/src/dhtproto/client/request/internal/GetChannels.d
@@ -40,7 +40,7 @@ import ocean.util.log.Logger;
 public struct GetChannels
 {
     import dhtproto.common.GetChannels;
-    import dhtproto.client.request.GetChannels;
+    public import dhtproto.client.request.GetChannels;
     import dhtproto.common.RequestCodes;
     import dhtproto.client.NotifierTypes;
     import swarm.neo.client.mixins.RequestCore;

--- a/src/dhtproto/client/request/internal/Mirror.d
+++ b/src/dhtproto/client/request/internal/Mirror.d
@@ -41,7 +41,7 @@ import ocean.core.Verify;
 public struct Mirror
 {
     import dhtproto.common.Mirror;
-    import dhtproto.client.request.Mirror;
+    public import dhtproto.client.request.Mirror;
     import dhtproto.common.RequestCodes;
     import dhtproto.client.NotifierTypes;
     import swarm.neo.client.mixins.RequestCore;

--- a/src/dhtproto/client/request/internal/Remove.d
+++ b/src/dhtproto/client/request/internal/Remove.d
@@ -53,7 +53,7 @@ static this ( )
 public struct Remove
 {
     import dhtproto.common.Remove;
-    import dhtproto.client.request.Remove;
+    public import dhtproto.client.request.Remove;
     import dhtproto.common.RequestCodes;
     import swarm.neo.client.mixins.RequestCore;
     import swarm.neo.client.RequestHandlers;

--- a/src/dhtproto/client/request/internal/RemoveChannel.d
+++ b/src/dhtproto/client/request/internal/RemoveChannel.d
@@ -40,7 +40,7 @@ import ocean.util.log.Logger;
 public struct RemoveChannel
 {
     import dhtproto.common.RemoveChannel;
-    import dhtproto.client.request.RemoveChannel;
+    public import dhtproto.client.request.RemoveChannel;
     import dhtproto.common.RequestCodes;
     import dhtproto.client.NotifierTypes;
     import swarm.neo.client.mixins.RequestCore;

--- a/src/dhtproto/client/request/internal/Update.d
+++ b/src/dhtproto/client/request/internal/Update.d
@@ -55,7 +55,7 @@ public struct Update
 {
     import dhtproto.common.Update;
     import dhtproto.common.RequestCodes;
-    import dhtproto.client.request.Update;
+    public import dhtproto.client.request.Update;
     import swarm.neo.AddrPort;
     import swarm.neo.client.mixins.RequestCore;
     import swarm.neo.client.RequestHandlers;


### PR DESCRIPTION
This does not address the use of deprecated features,, which still generate dozens of warnings, but it does fix the errors.

Two groups of compilation errors are fixed:
* The swarm mixins need access to the Notification type, so the imports of the Requests need to be made public.

* The NeoSupport Internal mixin has an Internals struct. The imports inside it need to be transitive.

The same changes need to be made in dmqproto and dlsproto.
