### PR TITLE
Add annotations for functions which `return &this`

### DIFF
--- a/src/dhtproto/client/legacy/internal/RequestSetup.d
+++ b/src/dhtproto/client/legacy/internal/RequestSetup.d
@@ -61,7 +61,7 @@ public template IODelegate ( )
 
     ***************************************************************************/
 
-    public This* io ( T ) ( T io )
+    public This* io ( T ) ( T io ) return
     {
         this.io_item = this.io_item(io);
         return &this;
@@ -125,7 +125,7 @@ public template Filter ( )
 
     ***************************************************************************/
 
-    public This* filter ( cstring filter )
+    public This* filter ( cstring filter ) return
     {
         this.filter_string = filter;
 
@@ -206,7 +206,7 @@ public template Key ( )
 
     ***************************************************************************/
 
-    public This* key ( Key ) ( Key key )
+    public This* key ( Key ) ( Key key ) return
     {
         version (X86_64) static assert(!is( Key == uint),
             "Please use hash_t instead of uint.");
@@ -226,7 +226,7 @@ public template Key ( )
 
     ***************************************************************************/
 
-    public This* contextFromKey ( )
+    public This* contextFromKey ( ) return
     {
         this.user_context = RequestContext(this.hash);
 


### PR DESCRIPTION
From dmd2.092 onwards, functions which use the `return &this` method
chaining idiom, must be marked with the `return` annotation. This makes
it impossible for @safe code to have references to destructed stack objects
(see DIP25).