### PR TITLE
Fixes for dmd 2.092

### DIFF
--- a/src/dhtproto/client/UsageExamples.d
+++ b/src/dhtproto/client/UsageExamples.d
@@ -1223,11 +1223,11 @@ unittest
 
             // Per-request stats.
             auto rq_stats = this.dht.neo.new RequestStats;
-            foreach ( name, stats; rq_stats.allRequests() )
+            foreach ( name, s; rq_stats.allRequests() )
             {
                 // See swarm.neo.client.requests.Stats
                 this.log.info("{} {} requests handled, mean time: {}μs",
-                    stats.count, name, stats.mean_time_micros());
+                    s.count, name, s.mean_time_micros());
             }
         }
 

--- a/src/dhtproto/node/neo/request/Mirror.d
+++ b/src/dhtproto/node/neo/request/Mirror.d
@@ -290,7 +290,7 @@ public abstract class MirrorProtocol_v0 : IRequest
 
         ***********************************************************************/
 
-        public void opPostInc ( )
+        public void opUnary(string op : "++") ( )
         {
             this.last_overflow_time = time(null);
             this.count_since_last_notification++;

--- a/src/dhttest/util/LocalStore.d
+++ b/src/dhttest/util/LocalStore.d
@@ -459,8 +459,8 @@ public struct NeoVerifier
 
         mstring buf;
         mstring[] channels;
-        foreach ( channel; dht.blocking.getChannels(buf) )
-            channels ~= channel.dup;
+        foreach ( chan; dht.blocking.getChannels(buf) )
+            channels ~= chan.dup;
 
         test(channels.contains(channel));
     }


### PR DESCRIPTION
After this fix is made, if the submodules are updated, then dhtproto compiles cleanly with the beta of dmd 2.092, except for dip25 warnings from two lines in swarm.